### PR TITLE
 Fix exception if OPBEANS_SERVICES wasn't passed

### DIFF
--- a/opbeans/src/main/java/co/elastic/apm/opbeans/controllers/DTInterceptor.java
+++ b/opbeans/src/main/java/co/elastic/apm/opbeans/controllers/DTInterceptor.java
@@ -34,8 +34,9 @@ public class DTInterceptor extends HandlerInterceptorAdapter {
     private Random random = new Random();
 
     public DTInterceptor(Environment env) {
-        
+
         hostList = env.getProperty("OPBEANS_SERVICES", "").split(",");
+        hostList = Arrays.stream(hostList).filter(s -> !s.equals("")).toArray(String[]::new);
         try {
             dtProb = Float.parseFloat(env.getProperty("OPBEANS_DT_PROBABILITY", "0.5"));
         } catch (NumberFormatException ex) {


### PR DESCRIPTION
Fix for #16 
Also will remove empty strings on passed values like `c,,c,c,,c,`