### PR TITLE
put apt cleanup in same docker layer as apt install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,9 @@ RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.arg
 FROM openjdk:10-jre-slim
 
 RUN export
-RUN apt-get update && apt-get install -y -qq curl
-RUN rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true
+RUN apt-get update && apt-get install -y -qq curl \
+    && rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true
+
 WORKDIR /app
 COPY --from=0 /usr/src/java-app/*.jar ./
 


### PR DESCRIPTION
the clean-up needs to run in the same `RUN` command, otherwise the data remains
in the layer created by the first `RUN`

See also https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get