### PR TITLE
ci(jenkins): Update Jenkins badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://apm-ci.elastic.co/job/apm-agent-java/job/opbeans-java-mbp/job/master/badge/icon)](https://apm-ci.elastic.co/job/apm-agent-java/job/opbeans-java-mbp/job/master/)
+[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-java%2Fopbeans-java-mbp%2Fmaster)](https://apm-ci.elastic.co/job/apm-agent-java/job/opbeans-java-mbp/job/master/)
 
 # opbeans-java
 This is an implementation of the [Opbeans Demo app](http://opbeans.com) in Java as an [Spring Boot](https://projects.spring.io/spring-boot/) application . It uses the same


### PR DESCRIPTION
## What is this PR doing?
It updates Jenkins badge for the master branch, using the unprotected one, so that anybody wit ViewStatus access can read it.

**protected** exposes the badge to users having at least Read permission on the job
**unprotected** exposes the badge to users having at least ViewStatus permission on the job

## Why is it important?
We want to keep al projects in sync in terms of CI, so that we can be even more transparent about the status of the project.