### PR TITLE
fix: bump OpenJDK Docker container version due libcrypt issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.arg
 #Run application Stage
 #We only need java
 
-FROM openjdk:10-jre-slim
+FROM openjdk:11-slim
 
 RUN export
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.arg
 #Run application Stage
 #We only need java
 
-FROM openjdk:11-slim
+FROM adoptopenjdk:11-jre-hotspot
 
 RUN export
 RUN apt-get update \

--- a/opbeans/pom.xml
+++ b/opbeans/pom.xml
@@ -102,6 +102,11 @@
 			<version>${elasticsearch.version}</version>
 		</dependency>
 
+		<dependency>
+		    <groupId>org.javassist</groupId>
+		    <artifactId>javassist</artifactId>
+		    <version>3.23.1-GA</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
bump OpenJDK Docker container version due libcrypt issues see https://github.com/elastic/apm-integration-testing/issues/801

we hit also https://github.com/spring-projects/spring-boot/issues/14610 so we have to update dependencies too