### PR TITLE
Adding load generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,12 @@ Another possible way is to create a different property file like application-cus
 
 ## Demo notes
 
-The application has a built-in bug that you can trigger by
-navigating to the path `/is-it-coffee-time`.
+The application has a built-in bug that you can trigger by navigating to the path `/is-it-coffee-time`.
+
+There is a load generator Docker image that you can build with the following command:
+
+    docker build -t opbeans-java-loadgen -f loadgen/Dockerfile loadgen
+
+Then you can run `opbeans-java-loadgen` as follows:
+
+    docker run --name opbeans-java-loadgen --network=host -d opbeans-java-loadgen 

--- a/loadgen/Dockerfile
+++ b/loadgen/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:8
+
+RUN apt-get update && apt-get install -y \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+    gnupg \
+	--no-install-recommends \
+	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+	&& echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+	&& apt-get update && apt-get install -y \
+	google-chrome-stable \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Add Chrome as a user
+RUN groupadd -r chrome && useradd -r -g chrome -G audio,video chrome \
+    && mkdir -p /home/chrome && chown -R chrome:chrome /home/chrome
+
+WORKDIR /home/chrome
+
+# Run Chrome non-privileged
+USER chrome
+
+# Expose port 9222
+EXPOSE 9222
+
+COPY package*.json /home/chrome/
+
+RUN npm install
+
+ENV CHROME_PATH=/usr/bin/chromium-browser
+
+COPY tasks.js /home/chrome/
+COPY processes.config.js /home/chrome/
+
+CMD ["node_modules/.bin/pm2-docker", "processes.config.js"]

--- a/loadgen/package.json
+++ b/loadgen/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "opbeans-java-loadgen",
+  "version": "1.0.0",
+  "description": "Load generator for opbeans-java",
+  "dependencies": {
+    "chromeless": "^1.5.2",
+    "pm2": "^3.0.3"
+  }
+}

--- a/loadgen/processes.config.js
+++ b/loadgen/processes.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    apps : [{
+        name: "chrome",
+        script: "google-chrome",
+        args: "--remote-debugging-address=0.0.0.0 --remote-debugging-port=9222 --disable-gpu --headless --no-sandbox",
+        exec_interpreter: "none",
+        exec_mode: "fork",
+        restart_delay: 2000
+    }, {
+        name: "worker",
+        script: "./tasks.js",
+        instances: 1,
+    }]
+}

--- a/loadgen/tasks.js
+++ b/loadgen/tasks.js
@@ -1,0 +1,88 @@
+const { Chromeless } = require('chromeless');
+
+var baseUrl = process.env.OPBEANS_BASE_URL || 'http://localhost:8080';
+var url = baseUrl
+var NUM_IPS = 1000;
+var RANDOM_IPS = loadRandomIPs();
+
+const chromeless = new Chromeless({ launchChrome: true,  waitTimeout: 30000 });
+
+function sleep(ms){
+    return new Promise(resolve=>{
+        setTimeout(resolve,ms)
+    })
+}
+
+async function run() {
+    url = await chromeless
+        .goto(url)
+        .setExtraHTTPHeaders({
+            'X-Forwarded-For': selectRandomIP()
+        })
+        .evaluate((baseUrl, url) => {
+            var links = document.querySelectorAll('a[href^="/"]');
+            var uniq_links = {};
+            for ( var i=0, len=links.length; i < len; i++ ) {
+                uniq_links[links[i].href] = links[i].href;
+            }
+            links = new Array();
+            for ( var key in uniq_links ) {
+                links.push(uniq_links[key]);
+            }
+            console.log(links)
+            if (links && links.length) {
+                var i = Math.floor(Math.random()*links.length);
+                return links[i];
+            } else {
+                //no links to follow so return to the base
+                return baseUrl;
+            }
+        }, baseUrl, url);
+    console.log(url);
+}
+
+async function safe_run() {
+    console.log('Starting from baseurl: '+url)
+    for(;;) {
+        run().catch(async (error) => {
+            console.log("failed for url")
+        console.log(error);
+    });
+        await sleep(6000 + Math.floor(Math.random()*10000));
+    }
+}
+
+function selectRandomIP() {
+    return RANDOM_IPS[Math.floor(Math.random() * RANDOM_IPS.length)];
+}
+
+function loadRandomIPs() {
+    var IPs = [];
+    while (IPs.length < NUM_IPS) {
+        var randomIP = randomIp();
+        if (IPs.indexOf(randomIP) === -1) {
+            IPs.push(randomIP);
+        }
+    }
+    return IPs;
+}
+
+
+function randomByte () {
+    return Math.round(Math.random()*256);
+}
+
+function isPrivate(ip) {
+    return /^10\.|^192\.168\.|^172\.16\.|^172\.17\.|^172\.18\.|^172\.19\.|^172\.20\.|^172\.21\.|^172\.22\.|^172\.23\.|^172\.24\.|^172\.25\.|^172\.26\.|^172\.27\.|^172\.28\.|^172\.29\.|^172\.30\.|^172\.31\./.test(ip);
+}
+
+function randomIp() {
+    var ip = randomByte() +'.' +
+        randomByte() +'.' +
+        randomByte() +'.' +
+        randomByte();
+    if (isPrivate(ip)) { return randomIp(); }
+    return ip;
+}
+
+safe_run().catch(console.error.bind(console))


### PR DESCRIPTION
This PR adds a load generator that is based on the [Petclinic](https://github.com/elastic/spring-petclinic) frontend load generator. The purpose is to make it easier to generate load when doing APM demos with `opbeans-java`. 