### PR TITLE
docker: add labels metadata

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -5,8 +5,11 @@ AGENT_VERSION="${1:?"Please set the java agent version"}"
 
 # Update agent dependencies
 cd opbeans
-./mvnw -B versions:use-dep-version -DdepVersion=${AGENT_VERSION} -Dincludes=co.elastic.apm:apm-agent-api
+./mvnw -B versions:use-dep-version -DdepVersion="${AGENT_VERSION}" -Dincludes=co.elastic.apm:apm-agent-api
+
+## Bump agent version in the Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
 
 # Commit changes
-git add pom.xml
+git add pom.xml Dockerfile
 git commit -m "Bump version ${AGENT_VERSION}"

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -8,7 +8,7 @@ cd opbeans
 ./mvnw -B versions:use-dep-version -DdepVersion="${AGENT_VERSION}" -Dincludes=co.elastic.apm:apm-agent-api
 
 ## Bump agent version in the Dockerfile
-sed -ibck "s#\(org.label-schema.version=\)\(.*\)#\1\"${AGENT_VERSION}\"#g" Dockerfile
+sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" Dockerfile
 
 # Commit changes
 git add pom.xml Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,15 @@ RUN apt-get update \
 WORKDIR /app
 COPY --from=0 /usr/src/java-app/*.jar ./
 
+LABEL \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vendor="Elastic" \
+    org.label-schema.name="opbeans-java" \
+    org.label-schema.version="1.3.0" \
+    org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-java" \
+    org.label-schema.vcs-url="https://github.com/elastic/opbeans-java" \
+    org.label-schema.license="MIT"
+
 CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
                                         -Dserver.port=${OPBEANS_SERVER_PORT:-}\
                                         -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\


### PR DESCRIPTION
Added some labels to easily identify what's the agent version that the opbeans is consuming, in addition to some labels that are generated for some other Elastic docker images.

### Tests

```bash
$ IMAGE=docker.elastic.co/observability-ci/opbeans-java:3ef66293e40d4169db7c9b2632b21db23a45afbf
$ docker pull ${IMAGE}
$ docker inspect ${IMAGE} | jq -r '.[0].Config.Labels'
{
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "opbeans-java",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://hub.docker.com/r/opbeans/opbeans-java",
  "org.label-schema.vcs-url": "https://github.com/elastic/opbeans-java",
  "org.label-schema.vendor": "Elastic",
  "org.label-schema.version": "1.3.0"
}
```