### PR TITLE
fix: skip git-commit-id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,20 +15,31 @@ WORKDIR /usr/src/java-code/opbeans
 #Bring the latest frontend code
 COPY --from=opbeans/opbeans-frontend:latest /app/build src/main/resources/public
 
-RUN mvn -q -B package -DskipTests
+RUN mvn -q --batch-mode package \
+  -DskipTests \
+  -Dmaven.repo.local=.m2 \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  -Dmaven.wagon.http.retryHandler.count=3 \
+  -Dhttps.protocols=TLSv1.2 \
+  -Dhttp.keepAlive=false \
+  -Dmaven.javadoc.skip=true \
+  -DskipTests=true \
+  -Dmaven.gitcommitid.skip=true
 RUN cp -v /usr/src/java-code/opbeans/target/*.jar /usr/src/java-app/app.jar
 
 #build the agent
 WORKDIR /usr/src/java-agent-code
 RUN curl -L https://github.com/$JAVA_AGENT_REPO/archive/$JAVA_AGENT_BRANCH.tar.gz | tar --strip-components=1 -xz
-ENV MAVEN_CONFIG=-Dmaven.repo.local=.m2
-RUN ./mvnw clean package \
-  -DskipTests=true \
-  -Dmaven.javadoc.skip=true \
-  -Dhttps.protocols=TLSv1.2 \
+RUN mvn -q --batch-mode clean package \
+  -Dmaven.repo.local=.m2 \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
   -Dmaven.wagon.http.retryHandler.count=3 \
+  -Dhttps.protocols=TLSv1.2 \
   -Dhttp.keepAlive=false \
-  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  -Dmaven.javadoc.skip=true \
+  -DskipTests=true \
+  -Dmaven.gitcommitid.skip=true
+
 RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
     && cp -v /usr/src/java-agent-code/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /usr/src/java-app/elastic-apm-agent.jar
 
@@ -39,7 +50,7 @@ RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.arg
 FROM adoptopenjdk:11-jre-hotspot
 
 RUN export
-RUN apt-get update \
+RUN apt-get -qq update \
  && apt-get install --no-install-recommends -y -qq curl \
  && rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=opbeans/opbeans-frontend:latest /app/build src/main/resources/public
 RUN mvn -q --batch-mode package \
   -DskipTests \
   -Dmaven.repo.local=.m2 \
-  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  --no-transfer-progress \
   -Dmaven.wagon.http.retryHandler.count=3 \
   -Dhttps.protocols=TLSv1.2 \
   -Dhttp.keepAlive=false \
@@ -32,7 +32,7 @@ WORKDIR /usr/src/java-agent-code
 RUN curl -L https://github.com/$JAVA_AGENT_REPO/archive/$JAVA_AGENT_BRANCH.tar.gz | tar --strip-components=1 -xz
 RUN mvn -q --batch-mode clean package \
   -Dmaven.repo.local=.m2 \
-  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  --no-transfer-progress \
   -Dmaven.wagon.http.retryHandler.count=3 \
   -Dhttps.protocols=TLSv1.2 \
   -Dhttp.keepAlive=false \


### PR DESCRIPTION
* Use maven to all the build instead mwnw, we are using a maven Docker container and we use maven in one place and the wrapper in another place, let's use always maven and remove a layer.
* Remove verbose output of maven
* Skip git-commit-id stage