### PR TITLE
[dependabot] enable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+---
+version: 2
+updates:
+  # Enable version updates for maven
+  - package-ecosystem: "maven"
+    # Look for `pom.xml` file in the `opbeans` directory
+    directory: "/opbeans/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-java"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "elastic/apm-agent-java"


### PR DESCRIPTION
### What

Enable dependabot to monitor any of the dependencies and notify the apm-agent-java team


### Why

Bump versions when required and monitor the ones related to any security issues