### PR TITLE
Allow switching between Otel and Elastic APM instrumentation through an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 #Multi-Stage build
-ARG APM_AGENT_TYPE=elasticapm
 
 #Build application stage
 #We need maven.
-
 FROM maven:3.8.4-jdk-11
-
-ARG JAVA_AGENT_BRANCH=master
-ARG JAVA_AGENT_REPO=elastic/apm-agent-java
-ARG OTEL_JAVA_AGENT_VERSION=v1.10.1
-
 WORKDIR /usr/src/java-app
 
 #build the application
@@ -19,7 +12,7 @@ WORKDIR /usr/src/java-code/opbeans
 #Bring the latest frontend code
 COPY --from=opbeans/opbeans-frontend:latest /app src/main/resources/public
 
-RUN mvn -X --batch-mode package \
+RUN mvn -q --batch-mode package \
   -DskipTests \
   -Dmaven.repo.local=.m2 \
   --no-transfer-progress \
@@ -47,6 +40,9 @@ COPY --from=0 /usr/src/java-app/*.jar ./
 # updated by .ci/bump-version.sh
 COPY --from=docker.elastic.co/observability/apm-agent-java:1.29.0 /usr/agent/elastic-apm-agent.jar /app/elastic-apm-agent.jar
 
+#Download the opentelemetry agent
+RUN curl -L https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.10.1/opentelemetry-javaagent.jar --output /app/opentelemetry-javaagent.jar
+
 # updated by .ci/bump-version.sh
 LABEL \
     org.label-schema.schema-version="1.0" \
@@ -57,25 +53,6 @@ LABEL \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-java" \
     org.label-schema.license="MIT"
 
-FROM base AS branch-version-elasticapm
-CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
-                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
-                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
-                                        -Dspring.datasource.url=${DATABASE_URL:-}\
-                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
-                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
-                                        -jar /app/app.jar
-
-FROM base AS branch-version-opentelemetry
-CMD java -javaagent:opentelemetry-javaagent.jar\
-                                      -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
-                                      -Dserver.port=${OPBEANS_SERVER_PORT:-}\
-                                      -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
-                                      -Dspring.datasource.url=${DATABASE_URL:-}\
-                                      -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
-                                      -Dspring.jpa.database=${DATABASE_DIALECT:-}\
-                                      -Dotel.instrumentation.runtime-metrics.enabled=true\
-                                      -jar /app/app.jar
-
-FROM branch-version-${APM_AGENT_TYPE} AS final
-RUN echo "Start build with ${APM_AGENT_TYPE}"
+COPY ./start.sh .
+RUN chmod +x ./start.sh
+CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 #Multi-Stage build
+ARG APM_AGENT_TYPE=elasticapm
 
 #Build application stage
 #We need maven.
 FROM maven:3.8.4-jdk-11
+
 ARG JAVA_AGENT_BRANCH=master
 ARG JAVA_AGENT_REPO=elastic/apm-agent-java
+ARG OTEL_JAVA_AGENT_VERSION=v1.10.1
 
 WORKDIR /usr/src/java-app
 
@@ -27,32 +30,56 @@ RUN mvn -X --batch-mode package \
   -Dmaven.gitcommitid.skip=true
 RUN cp -v /usr/src/java-code/opbeans/target/*.jar /usr/src/java-app/app.jar
 
+#build the elastic APM agent
+WORKDIR /usr/src/java-agent-code
+RUN curl -L https://github.com/$JAVA_AGENT_REPO/archive/$JAVA_AGENT_BRANCH.tar.gz | tar --strip-components=1 -xz
+RUN mvn -q --batch-mode clean package \
+  -Dmaven.repo.local=.m2 \
+  --no-transfer-progress \
+  -Dmaven.wagon.http.retryHandler.count=3 \
+  -Dhttps.protocols=TLSv1.2 \
+  -Dhttp.keepAlive=false \
+  -Dmaven.javadoc.skip=true \
+  -DskipTests=true \
+  -Dmaven.gitcommitid.skip=true
+
+RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
+    && cp -v /usr/src/java-agent-code/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /usr/src/java-app/elastic-apm-agent.jar
+
+#Download the opentelemetry agent
+RUN curl -L https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$OTEL_JAVA_AGENT_VERSION/opentelemetry-javaagent.jar --output /usr/src/java-app/opentelemetry-javaagent.jar
+
 #Run application Stage
 #We only need java
-
-FROM adoptopenjdk:14-jre-hotspot
+FROM adoptopenjdk:14-jre-hotspot AS base
 
 RUN export
 RUN apt-get -qq update \
  && apt-get install --no-install-recommends -y -qq curl \
  && rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true
 
-ARG OTEL_JAVA_AGENT_VERSION=v1.10.1
-
 WORKDIR /app
 COPY --from=0 /usr/src/java-app/*.jar ./
-RUN curl -L https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$OTEL_JAVA_AGENT_VERSION/opentelemetry-javaagent.jar --output opentelemetry-javaagent.jar
-
 
 LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-java" \
-    org.label-schema.version="1.28.1" \
+    org.label-schema.version="1.28.4" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-java" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-java" \
     org.label-schema.license="MIT"
 
+FROM base AS branch-version-elasticapm
+CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
+                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
+                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
+                                        -Dspring.datasource.url=${DATABASE_URL:-}\
+                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
+                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
+                                        -jar /app/app.jar
+
+FROM base AS branch-version-opentelemetry
 CMD java -javaagent:opentelemetry-javaagent.jar\
                                       -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
                                       -Dserver.port=${OPBEANS_SERVER_PORT:-}\
@@ -62,3 +89,6 @@ CMD java -javaagent:opentelemetry-javaagent.jar\
                                       -Dspring.jpa.database=${DATABASE_DIALECT:-}\
                                       -Dotel.instrumentation.runtime-metrics.enabled=true\
                                       -jar /app/app.jar
+
+FROM branch-version-${APM_AGENT_TYPE} AS final
+RUN echo "Start build with ${APM_AGENT_TYPE}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 #Build application stage
 #We need maven.
-FROM maven:3.6.3-jdk-14
+FROM maven:3.8.4-jdk-11
 ARG JAVA_AGENT_BRANCH=master
 ARG JAVA_AGENT_REPO=elastic/apm-agent-java
 
@@ -13,9 +13,9 @@ ADD . /usr/src/java-code
 WORKDIR /usr/src/java-code/opbeans
 
 #Bring the latest frontend code
-COPY --from=opbeans/opbeans-frontend:latest /app/build src/main/resources/public
+COPY --from=opbeans/opbeans-frontend:latest /app src/main/resources/public
 
-RUN mvn -q --batch-mode package \
+RUN mvn -X --batch-mode package \
   -DskipTests \
   -Dmaven.repo.local=.m2 \
   --no-transfer-progress \
@@ -27,48 +27,38 @@ RUN mvn -q --batch-mode package \
   -Dmaven.gitcommitid.skip=true
 RUN cp -v /usr/src/java-code/opbeans/target/*.jar /usr/src/java-app/app.jar
 
-#build the agent
-WORKDIR /usr/src/java-agent-code
-RUN curl -L https://github.com/$JAVA_AGENT_REPO/archive/$JAVA_AGENT_BRANCH.tar.gz | tar --strip-components=1 -xz
-RUN mvn -q --batch-mode clean package \
-  -Dmaven.repo.local=.m2 \
-  --no-transfer-progress \
-  -Dmaven.wagon.http.retryHandler.count=3 \
-  -Dhttps.protocols=TLSv1.2 \
-  -Dhttp.keepAlive=false \
-  -Dmaven.javadoc.skip=true \
-  -DskipTests=true \
-  -Dmaven.gitcommitid.skip=true
-
-RUN export JAVA_AGENT_BUILT_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec) \
-    && cp -v /usr/src/java-agent-code/elastic-apm-agent/target/elastic-apm-agent-${JAVA_AGENT_BUILT_VERSION}.jar /usr/src/java-app/elastic-apm-agent.jar
-
-
 #Run application Stage
 #We only need java
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM adoptopenjdk:14-jre-hotspot
 
 RUN export
 RUN apt-get -qq update \
  && apt-get install --no-install-recommends -y -qq curl \
  && rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true
+
+ARG OTEL_JAVA_AGENT_VERSION=v1.10.1
+
 WORKDIR /app
 COPY --from=0 /usr/src/java-app/*.jar ./
+RUN curl -L https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/$OTEL_JAVA_AGENT_VERSION/opentelemetry-javaagent.jar --output opentelemetry-javaagent.jar
+
 
 LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-java" \
-    org.label-schema.version="1.28.4" \
+    org.label-schema.version="1.28.1" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-java" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-java" \
     org.label-schema.license="MIT"
 
-CMD java -javaagent:/app/elastic-apm-agent.jar -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
-                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
-                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
-                                        -Dspring.datasource.url=${DATABASE_URL:-}\
-                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
-                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
-                                        -jar /app/app.jar
+CMD java -javaagent:opentelemetry-javaagent.jar\
+                                      -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
+                                      -Dserver.port=${OPBEANS_SERVER_PORT:-}\
+                                      -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
+                                      -Dspring.datasource.url=${DATABASE_URL:-}\
+                                      -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
+                                      -Dspring.jpa.database=${DATABASE_DIALECT:-}\
+                                      -Dotel.instrumentation.runtime-metrics.enabled=true\
+                                      -jar /app/app.jar

--- a/docker-compose-elastic-cloud.yml
+++ b/docker-compose-elastic-cloud.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Dockerfile
       args:
         OTEL_JAVA_AGENT_VERSION: v1.10.1
+        APM_AGENT_TYPE: ${APM_AGENT_TYPE:-elasticapm}
     image: opbeans/opbeans-java:latest
     container_name: opbeans-java
     ports:

--- a/docker-compose-elastic-cloud.yml
+++ b/docker-compose-elastic-cloud.yml
@@ -1,7 +1,11 @@
 version: "2.1"
 services:
   opbeans-java:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        OTEL_JAVA_AGENT_VERSION: v1.10.1
     image: opbeans/opbeans-java:latest
     container_name: opbeans-java
     ports:

--- a/docker-compose-elastic-cloud.yml
+++ b/docker-compose-elastic-cloud.yml
@@ -19,6 +19,11 @@ services:
       - OPBEANS_SERVER_PORT=${OPBEANS_SERVER_PORT:-8000}
       - ELASTIC_APM_ENABLE_LOG_CORRELATION=true
       - ELASTIC_APM_ENVIRONMENT=production
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=${ELASTIC_APM_SERVICE_NAME:-opbeans-java},deployment.environment=production
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://apm-server:8200}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
     depends_on:
       apm-server:
         condition: service_healthy
@@ -69,7 +74,7 @@ services:
     depends_on:
       opbeans-java:
         condition: service_healthy
-      
+
 volumes:
   esdata:
     driver: local

--- a/docker-compose-elastic-cloud.yml
+++ b/docker-compose-elastic-cloud.yml
@@ -1,12 +1,7 @@
 version: "2.1"
 services:
   opbeans-java:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        OTEL_JAVA_AGENT_VERSION: v1.10.1
-        APM_AGENT_TYPE: ${APM_AGENT_TYPE:-elasticapm}
+    build: .
     image: opbeans/opbeans-java:latest
     container_name: opbeans-java
     ports:
@@ -29,6 +24,7 @@ services:
       - OTEL_METRICS_EXPORTER=otlp
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://apm-server:8200}
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - APM_AGENT_TYPE=${APM_AGENT_TYPE:-elasticapm}
     depends_on:
       apm-server:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: Dockerfile
       args:
         OTEL_JAVA_AGENT_VERSION: v1.10.1
+        APM_AGENT_TYPE: ${APM_AGENT_TYPE:-elasticapm}
     image: opbeans/opbeans-java:latest
     container_name: opbeans-java
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 version: "2.1"
 services:
   opbeans-java:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        OTEL_JAVA_AGENT_VERSION: v1.10.1
     image: opbeans/opbeans-java:latest
     container_name: opbeans-java
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,7 @@
 version: "2.1"
 services:
   opbeans-java:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        OTEL_JAVA_AGENT_VERSION: v1.10.1
-        APM_AGENT_TYPE: ${APM_AGENT_TYPE:-elasticapm}
+    build: .
     image: opbeans/opbeans-java:latest
     container_name: opbeans-java
     ports:
@@ -29,6 +24,7 @@ services:
       - OTEL_METRICS_EXPORTER=otlp
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://apm-server:8200}
       - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - APM_AGENT_TYPE=${APM_AGENT_TYPE:-elasticapm}
     depends_on:
       apm-server:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       - OPBEANS_SERVER_PORT=${OPBEANS_SERVER_PORT:-8000}
       - ELASTIC_APM_ENABLE_LOG_CORRELATION=true
       - ELASTIC_APM_ENVIRONMENT=production
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=${ELASTIC_APM_SERVICE_NAME:-opbeans-java},deployment.environment=production
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://apm-server:8200}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
     depends_on:
       apm-server:
         condition: service_healthy
@@ -119,7 +124,7 @@ services:
     depends_on:
       opbeans-java:
         condition: service_healthy
-        
+
 volumes:
   esdata:
     driver: local

--- a/start.sh
+++ b/start.sh
@@ -1,31 +1,35 @@
 #!/bin/sh
 
-case $APM_AGENT_TYPE in
-  "opentelemetry")
-  echo "opentelemetry"
-  java -javaagent:/app/opentelemetry-javaagent.jar\
-                                        -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
-                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
-                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
-                                        -Dspring.datasource.url=${DATABASE_URL:-}\
-                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
-                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
-                                        -Dotel.instrumentation.runtime-metrics.enabled=true\
-                                        -jar ./app.jar
-  ;;
-  "elasticapm")
-  echo "elasticapm"
-  java -javaagent:/app/elastic-apm-agent.jar\
-                                        -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
-                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
-                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
-                                        -Dspring.datasource.url=${DATABASE_URL:-}\
-                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
-                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
-                                        -jar ./app.jar
-  ;;
-  *)
-  echo "unknown agent type $APM_AGENT_TYPE"
-  ;;
-  esac
-fi
+set -euo pipefail
+
+JAVA_AGENT=''
+
+APP_OPTS=""
+APP_OPTS="${APP_OPTS} -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}"
+APP_OPTS="${APP_OPTS} -Dserver.port=${OPBEANS_SERVER_PORT:-}"
+APP_OPTS="${APP_OPTS} -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}"
+APP_OPTS="${APP_OPTS} -Dspring.datasource.url=${DATABASE_URL:-}"
+APP_OPTS="${APP_OPTS} -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}"
+APP_OPTS="${APP_OPTS} -Dspring.jpa.database=${DATABASE_DIALECT:-}"
+
+case "${APM_AGENT_TYPE}" in
+    "opentelemetry")
+        echo "opentelemetry"
+        JAVA_AGENT="-javaagent:/app/opentelemetry-javaagent.jar"
+        APP_OPTS="${APP_OPTS} -Dotel.instrumentation.runtime-metrics.enabled=true"
+        ;;
+    "elasticapm")
+        echo "elasticapm"
+        JAVA_AGENT="-javaagent:/app/elastic-apm-agent.jar"
+        ;;
+    *)
+        echo "unknown agent type $APM_AGENT_TYPE"
+        exit 1
+        ;;
+esac
+
+java \
+    ${JAVA_AGENT} \
+    ${APP_OPTS} \
+    -jar ./app.jar
+

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 
@@ -32,4 +32,3 @@ java \
     ${JAVA_AGENT} \
     ${APP_OPTS} \
     -jar ./app.jar
-

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+case $APM_AGENT_TYPE in
+  "opentelemetry")
+  echo "opentelemetry"
+  java -javaagent:/app/opentelemetry-javaagent.jar\
+                                        -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
+                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
+                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
+                                        -Dspring.datasource.url=${DATABASE_URL:-}\
+                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
+                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
+                                        -Dotel.instrumentation.runtime-metrics.enabled=true\
+                                        -jar ./app.jar
+  ;;
+  "elasticapm")
+  echo "elasticapm"
+  java -javaagent:/app/elastic-apm-agent.jar\
+                                        -Dspring.profiles.active=${OPBEANS_JAVA_PROFILE:-}\
+                                        -Dserver.port=${OPBEANS_SERVER_PORT:-}\
+                                        -Dserver.address=${OPBEANS_SERVER_ADDRESS:-0.0.0.0}\
+                                        -Dspring.datasource.url=${DATABASE_URL:-}\
+                                        -Dspring.datasource.driverClassName=${DATABASE_DRIVER:-}\
+                                        -Dspring.jpa.database=${DATABASE_DIALECT:-}\
+                                        -jar ./app.jar
+  ;;
+  *)
+  echo "unknown agent type $APM_AGENT_TYPE"
+  ;;
+  esac
+fi


### PR DESCRIPTION
### Motivation / Summary
The purpose of this pull request is to instrument this sample app with the OpenTelemetry Java agent, in order to leverage the OpenTelemetry compatibility offered by the APM server.

### Elements to Review
3 files have been modified : 
- `Dockerfile` - Instead of building the APM agent, the Otel agent is downloaded and is used through the `-javaagent` flag. The Maven and OpenJDK images have also been bumped in order to build images compatible with M1 Macs.
- `docker-compose.yml` - Relevant environment variables are set.
- `docker-compose-elastic-cloud.yml` - Relevant environment variables are set.

### Checklist

- [x] Instrument the app with Otel agent.
- [x] Define a strategy allowing to switch between agents : change Docker entrypoint depending on env. var.

### How to test
- Clone the repo
- Launch Docker Compose. 