### PR TITLE
Reuse built agent in Docker image

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -9,6 +9,7 @@ cd opbeans
 
 ## Bump agent version in the Dockerfile
 sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" ../Dockerfile
+sed -ibck "s#\(--from=docker.elastic.co/observability/apm-agent-java:\).*\( .*\)#\1${AGENT_VERSION}\2#g" ../Dockerfile
 
 # Commit changes
 git add pom.xml ../Dockerfile

--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -9,7 +9,7 @@ cd opbeans
 
 ## Bump agent version in the Dockerfile
 sed -ibck "s#\(org.label-schema.version=\)\(\".*\"\)\(.*\)#\1\"${AGENT_VERSION}\"\3#g" ../Dockerfile
-sed -ibck "s#\(--from=docker.elastic.co/observability/apm-agent-java:\).*\( .*\)#\1${AGENT_VERSION}\2#g" ../Dockerfile
+sed -ibck "s#\(apm-agent-java:\)[^ ]* #\1${AGENT_VERSION} #g" ../Dockerfile
 
 # Commit changes
 git add pom.xml ../Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,6 @@ RUN mvn -q --batch-mode package \
   -Dmaven.gitcommitid.skip=true
 RUN cp -v /usr/src/java-code/opbeans/target/*.jar /usr/src/java-app/app.jar
 
-# Copy Elastic agent from docker image
-# updated by .ci/bump-version.sh
-WORKDIR /app
-COPY --from=docker.elastic.co/observability/apm-agent-java:1.29.0 /usr/agent/elastic-apm-agent.jar elastic-apm-agent.jar
-
 #Run application Stage
 #We only need java
 
@@ -41,6 +36,10 @@ RUN apt-get -qq update \
  && rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true
 WORKDIR /app
 COPY --from=0 /usr/src/java-app/*.jar ./
+
+# Copy Elastic agent from docker image
+# updated by .ci/bump-version.sh
+COPY --from=docker.elastic.co/observability/apm-agent-java:1.29.0 /usr/agent/elastic-apm-agent.jar /app/elastic-apm-agent.jar
 
 # updated by .ci/bump-version.sh
 LABEL \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@
 #Build application stage
 #We need maven.
 FROM maven:3.6.3-jdk-14
-ARG JAVA_AGENT_BRANCH=master
-ARG JAVA_AGENT_REPO=elastic/apm-agent-java
 
 WORKDIR /usr/src/java-app
 
@@ -28,6 +26,7 @@ RUN mvn -q --batch-mode package \
 RUN cp -v /usr/src/java-code/opbeans/target/*.jar /usr/src/java-app/app.jar
 
 # Copy Elastic agent from docker image
+# updated by .ci/bump-version.sh
 WORKDIR /app
 COPY --from=docker.elastic.co/observability/apm-agent-java:1.29.0 /usr/agent/elastic-apm-agent.jar elastic-apm-agent.jar
 
@@ -43,11 +42,12 @@ RUN apt-get -qq update \
 WORKDIR /app
 COPY --from=0 /usr/src/java-app/*.jar ./
 
+# updated by .ci/bump-version.sh
 LABEL \
     org.label-schema.schema-version="1.0" \
     org.label-schema.vendor="Elastic" \
     org.label-schema.name="opbeans-java" \
-    org.label-schema.version="1.28.4" \
+    org.label-schema.version="1.29.0" \
     org.label-schema.url="https://hub.docker.com/r/opbeans/opbeans-java" \
     org.label-schema.vcs-url="https://github.com/elastic/opbeans-java" \
     org.label-schema.license="MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN cp -v /usr/src/java-code/opbeans/target/*.jar /usr/src/java-app/app.jar
 
 # Copy Elastic agent from docker image
 WORKDIR /app
-COPY --from=docker.elastic.co/observability/apm-agent-java:1.28.4 \
-    /usr/agent/elastic-apm-agent.jar \
-    elastic-apm-agent.jar
+COPY --from=docker.elastic.co/observability/apm-agent-java:1.29.0 /usr/agent/elastic-apm-agent.jar elastic-apm-agent.jar
 
 #Run application Stage
 #We only need java

--- a/opbeans/pom.xml
+++ b/opbeans/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>co.elastic.apm</groupId>
 			<artifactId>apm-agent-api</artifactId>
-			<version>1.28.4</version>
+			<version>1.29.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
- reuse build apm agent instead of re-building.
- updating agent version through `.ci/bump-version.sh` is still supported
