### PR TITLE
Added STACK_VERSION to the Elastic Cloud section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ docker-compose up
 
 0. Start Elastic Cloud [trial](https://www.elastic.co/cloud/elasticsearch-service/signup) (if you don't have it yet)
 1. Add environmental variables `ELASTIC_CLOUD_ID` and `ELASTIC_CLOUD_CREDENTIALS` (in format `login:password`)
-2. Run
+2. Add environmental variable `STACK_VERSION` to match your deployed Elasticsearch version.
+3. Run
 ```bash
 docker-compose -f docker-compose-elastic-cloud.yml up
 ```


### PR DESCRIPTION
It isn't obvious what is wrong when data isn't flowing after following the instructions for Elastic Cloud.  After realizing I needed to set STACK_VERSION to make it work, it seems like it would be best to include this in the instructions.  Maybe even require it in the future with warnings when they are missing like for the ELASTIC_CLOUD_ID and ELASTIC_CLOUD_CREDENTIALS variables.