### PR TITLE
action: release from main the latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,26 @@ jobs:
         name: test-results
         path: target/*.xml
 
+  release:
+    runs-on: ubuntu-latest
+    needs: [ test ]
+    if:
+      contains('
+        refs/heads/main
+      ', github.ref)
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: elastic/apm-pipeline-library/.github/actions/docker-login@gh_actions
+      with:
+        registry: docker.elastic.co
+        secret: secret/observability-team/ci/docker-registry/prod
+        url: ${{ secrets.VAULT_ADDR }}
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+    - name: Run publish
+      run: make publish
+      env:
+        VERSION: latest


### PR DESCRIPTION
### What

This approach will publish the docker images in DockerHub for the latest version.

### Why

It uses the same workflow so the git sha commit is implicitly the same one. If splitting in a different workflow then we need to solve the git sha commit detection where the release should be generated from. We will probably change this implementation later on.

### Follow ups

- Support publishing docker images from tag releases
- Support publishing docker images from PRs in the staging environment