### PR TITLE
updatecli: use xml target to update the apm-agent-java version in the pom.xml

### DIFF
--- a/.ci/bump-version.sh
+++ b/.ci/bump-version.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-AGENT_VERSION="${1:?"Please set the java agent version"}"
-
-# Update agent dependencies
-cd opbeans
-./mvnw -B versions:use-dep-version -DdepVersion="${AGENT_VERSION}" -Dincludes=co.elastic.apm:apm-agent-api

--- a/.ci/updatecli.d/bump-version.yml
+++ b/.ci/updatecli.d/bump-version.yml
@@ -67,13 +67,13 @@ targets:
         - name: PATH
   pom_xml:
     name: Update maven package version
+    sourceid: elastic-apm-agent-java
     scmid: githubConfig
     kind: xml
-    disablesourceinput: true
     spec:
       file: opbeans/pom.xml
       path: "/project/properties/version.apm-agent-java"
-      value: "{{ source `elastic-apm-agent-java` }}"
+      value: '{{ source "elastic-apm-agent-java" }}'
   dockerfile_schema_version:
     name: Set org.label-schema.version in Dockerfile
     sourceid: elastic-apm-agent-java

--- a/.ci/updatecli.d/bump-version.yml
+++ b/.ci/updatecli.d/bump-version.yml
@@ -65,6 +65,15 @@ targets:
       command: .ci/bump-version.sh
       environments:
         - name: PATH
+  pom_xml:
+    name: Update maven package version
+    scmid: githubConfig
+    kind: xml
+    disablesourceinput: true
+    spec:
+      file: opbeans/pom.xml
+      path: "/project/properties/version.apm-agent-java"
+      value: "{{ source `elastic-apm-agent-java` }}"
   dockerfile_schema_version:
     name: Set org.label-schema.version in Dockerfile
     sourceid: elastic-apm-agent-java

--- a/opbeans/pom.xml
+++ b/opbeans/pom.xml
@@ -28,6 +28,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
+		<!-- required this property so the updatecli automation uses it -->
+		<version.apm-agent-java>1.41.0</version.apm-agent-java>
 	</properties>
 
 
@@ -67,7 +69,7 @@
 		<dependency>
 			<groupId>co.elastic.apm</groupId>
 			<artifactId>apm-agent-api</artifactId>
-			<version>1.41.0</version>
+			<version>${version.apm-agent-java}</version>
 		</dependency>
 
 		<!-- OpenTelemetry API + SDK -->


### PR DESCRIPTION
The shell target requires some extra steps so it can be updatecli compliance, see https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target

In this case, I decided to refactor the `pom.xml` so it uses properties then the `xml` target can be used with an xpath to update the version.
