### PR TITLE
github-action: provenance/attestations for dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,6 @@ jobs:
     - name: Attest image
       uses: github-early-access/generate-build-provenance@main
       with:
-        subject-name: ${{ env.DOCKER_IMAGE_NAME }}
+        subject-name: index.docker.io/${{ env.DOCKER_IMAGE_NAME }}
         subject-digest: ${{ steps.docker-push.outputs.digest }}
-        push-to-registry: false
+        push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
       uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
       with:
         context: .
+        provenance: mode=max
         push: true
+        sbom: true
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
 


### PR DESCRIPTION
> NOTE: When pushing to Docker Hub, please use "index.docker.io" as the registry portion of the image name.

And also support for the sbom and provenance support with the https://github.com/docker/build-push-action/tree/2cdde995de11925a030ce8070c3d77a52ffcf1c0/

See https://docs.docker.com/build/ci/github-actions/attestations/