### PR TITLE
github-action: use buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
       with:
         registry: docker.io


### PR DESCRIPTION
As explained in https://docs.docker.com/build/ci/github-actions/attestations/

otherwise

```
ERROR: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
Learn more at https://docs.docker.com/go/attestations/
Error: buildx failed with: Learn more at https://docs.docker.com/go/attestations/
```