### PR TITLE
ci: use updatecli with GitHub secrets

### DIFF
--- a/.ci/updatecli.d/bump-version.yml
+++ b/.ci/updatecli.d/bump-version.yml
@@ -16,6 +16,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: main
+      commitusingapi: true
 
 actions:
   opbeans-java:

--- a/.ci/updatecli.d/bump-version.yml
+++ b/.ci/updatecli.d/bump-version.yml
@@ -10,12 +10,11 @@ scms:
   githubConfig:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: elastic
       repository: opbeans-java
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: main
 
 actions:
@@ -37,7 +36,7 @@ sources:
       owner: elastic
       repository: apm-agent-java
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: semver
     transformers:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -17,16 +17,16 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: .ci/updatecli.d
+          command: "apply --config .ci/updatecli.d"
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
       - if: failure()
-        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        uses: elastic/oblt-actions/slack/send@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-java"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          command: "apply --config .ci/updatecli.d"
+          command: "--experimental apply --config .ci/updatecli.d"
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
 


### PR DESCRIPTION
Use oblt-actions and GitHub secrets for the `updatecli`.