### PR TITLE
update maven wrapper

### DIFF
--- a/opbeans/.mvn/wrapper/maven-wrapper.properties
+++ b/opbeans/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip


### PR DESCRIPTION
When trying to build locally with the maven wrapper, the build fails with the following message:

```
The plugin org.apache.maven.plugins:maven-compiler-plugin:3.13.0 requires Maven version 3.6.3
```

This PR just updates to the latest maven version.
The issue does not happen in CI because the build happens within a docker image and it's already using maven 3.9.6.