### PR TITLE
github(codeowners): robots-ci can review .github/workflows only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @elastic/apm-agent-java
 
-/.github @elastic/observablt-ci
+/.github/workflows @elastic/observablt-ci


### PR DESCRIPTION
This should help with letting the teams own other files under the .github folder